### PR TITLE
Allow contacting '127.0.0.1' instead of 'localhost'

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Both Kubernetes and Docker have the capability to run health checks against your
 
 Many folks use `curl` for this and it's not a bad tool, but it's overkill. In addition, many people would like to strip out tools like `curl` because they can be misused if your application is compromised.
 
-The tiny health checker is a small binary that can only make HTTP requests to localhost. The port and path are configurable, but that's it. This is sufficient for health checks, but should be difficult to misuse if your container is compromised.
+The tiny health checker is a small binary that can only make HTTP requests to localhost. The port and path are configurable, and you can specify using the loopback adapter address, but that's it. This is sufficient for health checks, but should be difficult to misuse if your container is compromised.
 
 ## Usage
 
@@ -17,11 +17,12 @@ USAGE:
 ENV:
 
 	THC_PORT sets the port to which a connection will be made, default: 8080
-	THC_PATH sets the path to which a connection will be made, default `/`
-	CONN_TIMEOUT sets the connection timeout, default: 10
-	REQ_TIMEOUT sets the request timeout, defaults: 15
+	THC_PATH sets the path to which a connection will be made, default: `/`
+	THC_CONN_TIMEOUT sets the connection timeout, default: 10
+	THC_REQ_TIMEOUT sets the request timeout, default: 15
+	THC_USE_LOOPBACK_ADDRESS 'true' to use 127.0.0.1 in place of 'localhost', default: `false`
 
-	**NOTE** Host is not configurable and will always be localhost
+	**NOTE** Host is not configurable and will always be localhost (or 127.0.0.1)
 ```
 
 ## Examples

--- a/src/args.rs
+++ b/src/args.rs
@@ -40,13 +40,16 @@ impl Config {
             use_loopback_addr: env::var("THC_USE_LOOPBACK_ADDRESS")
                 .unwrap_or_else(|_| "false".into())
                 .parse()
-                .expect("THC_USE_LOOPBACK_ADDRESS must be 'true' or 'false' if specified"), 
-
+                .expect("THC_USE_LOOPBACK_ADDRESS must be 'true' or 'false' if specified"),
         }
     }
 
     pub fn url(&self) -> String {
-        let host = if self.use_loopback_addr { "127.0.0.1" } else { "localhost" };
+        let host = if self.use_loopback_addr {
+            "127.0.0.1"
+        } else {
+            "localhost"
+        };
         format!("http://{}:{}{}", host, self.port, self.path)
     }
 
@@ -110,12 +113,8 @@ mod tests {
 
     #[test]
     fn it_parses_loopback_adress_override() {
-        temp_env::with_vars(
-            vec![("THC_USE_LOOPBACK_ADDRESS", Some("true"))],
-            || {
-                assert_eq!(Config::new(&[]).url(), "http://127.0.0.1:8080/");
-            },
-        );
+        temp_env::with_vars(vec![("THC_USE_LOOPBACK_ADDRESS", Some("true"))], || {
+            assert_eq!(Config::new(&[]).url(), "http://127.0.0.1:8080/");
+        });
     }
-
 }


### PR DESCRIPTION
Feature to allow running THC against 127.0.0.1 instead of localhost, for use in containers where name resolution is somehow disallowed or non-functional.

Activated by specifying THC_USE_LOOPBACK_ADDRESS=true in the environment.

Also fixed the usage docs just slightly.